### PR TITLE
Added a dismiss block

### DIFF
--- a/TOActionSheet/TOActionSheet.h
+++ b/TOActionSheet/TOActionSheet.h
@@ -60,6 +60,11 @@ Optionally, the text for the 'Cancel' button.
 @property (nonatomic, copy) NSString *cancelButtonTitle;
 
 /**
+ Optionally, a block that will be executed when the ActionSheet is dismissed.
+ */
+@property (nonatomic, copy) void (^actionSheetDismissedBlock)(void);
+
+/**
  Optionally, a block that will be executed when the 'Cancel' button is tapped.
  */
 @property (nonatomic, copy) void (^cancelButtonTappedBlock)(void);

--- a/TOActionSheet/TOActionSheet.m
+++ b/TOActionSheet/TOActionSheet.m
@@ -754,7 +754,10 @@ const CGFloat kTOActionSheetScreenPadding = 20.0f;
         self.containerView.frame = CGRectOffset(self.containerView.frame, 0.0f, offset);
         self.cancelButton.frame = CGRectOffset(self.cancelButton.frame, 0.0f, offset);
         self.backgroundColor = [UIColor clearColor];
-    } completion:^(BOOL complete) { [self removeFromSuperview]; }];
+    } completion:^(BOOL complete) {
+        [self removeFromSuperview];
+        self.actionSheetDismissedBlock();
+    }];
 }
 
 - (void)presentViewWithRegularAnimation
@@ -802,6 +805,7 @@ const CGFloat kTOActionSheetScreenPadding = 20.0f;
         self.backgroundColor = [UIColor clearColor];
      } completion:^(BOOL complete) {
          [self removeFromSuperview];
+         self.actionSheetDismissedBlock();
      }];
 }
 

--- a/TOActionSheetExample/ViewController.m
+++ b/TOActionSheetExample/ViewController.m
@@ -32,7 +32,10 @@
         UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Deleted!" message:@"The thing was deleted!" delegate:nil cancelButtonTitle:nil otherButtonTitles:@"Okay!", nil];
         [alertView show];
     }];
-    
+    actionSheet.actionSheetDismissedBlock = ^{
+        UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:@"Dismissed!" message:@"The action sheet was dismissed!" delegate:nil cancelButtonTitle:nil otherButtonTitles:@"Okay!", nil];
+        [alertView show];
+    };
     UIButton *button = (UIButton *)sender;
     [actionSheet showFromView:button inView:self.navigationController.view];
 }


### PR DESCRIPTION
I added a dismiss block to `TOActionSheet`. This means you can, for example, disable the button that shows the action sheet and then reenable it when the view is dismissed by a tap on the background.