### PR TITLE
Check for when actionSheetDismissedBlock() is nil

### DIFF
--- a/TOActionSheet/TOActionSheet.m
+++ b/TOActionSheet/TOActionSheet.m
@@ -814,7 +814,8 @@ const CGFloat kTOActionSheetScreenPadding = 20.0f;
         self.backgroundColor = [UIColor clearColor];
     } completion:^(BOOL complete) {
         [self removeFromSuperview];
-        self.actionSheetDismissedBlock();
+        if (self.actionSheetDismissedBlock)
+            self.actionSheetDismissedBlock();
     }];
 }
 
@@ -863,7 +864,8 @@ const CGFloat kTOActionSheetScreenPadding = 20.0f;
         self.backgroundColor = [UIColor clearColor];
      } completion:^(BOOL complete) {
          [self removeFromSuperview];
-         self.actionSheetDismissedBlock();
+         if (self.actionSheetDismissedBlock)
+             self.actionSheetDismissedBlock();
      }];
 }
 


### PR DESCRIPTION
This adds a bugfix for trying to call actionSheetDismissedBlock() even when it's nil. Last pull request, I swear. 😂